### PR TITLE
Fixing formatting of instructor and helper names

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@ humandate: Apr 30-May 1, 2015
 humantime: 8:30 am - 4:30 pm
 startdate: 2015-04-30
 enddate: 2015-05-01
-instructor: Daisie Huang, Doug Latornell, Andrew MacDonald, Bill Mills, Evan Morien, James Robinson, Tiffany Timbers, Thea Van Rossum
-helper: Remi Daigle, Bruno Grande, Catrina Loucks, Karina Musalem, Kwangjin Park, Nancy Soontiens
+instructor: ["Daisie Huang", "Doug Latornell", "Andrew MacDonald", "Bill Mills", "Evan Morien", "James Robinson", "Tiffany Timbers", "Thea Van Rossum"]
+helper: ["Remi Daigle", "Bruno Grande", "Catrina Loucks", "Karina Musalem", "Kwangjin Park", "Nancy Soontiens"]
 contact: tiffany.timbers@gmail.com
 etherpad: https://etherpad.mozilla.org/2015-04-30-SFU
 eventbrite: 16238071509


### PR DESCRIPTION
This turns the instructor and helper fields into lists - otherwise, the whole line is read as one long string by YAML.
